### PR TITLE
Release DDThreadLock during the FPS limit spinlock

### DIFF
--- a/DDrawCompat/DDraw/RealPrimarySurface.cpp
+++ b/DDrawCompat/DDraw/RealPrimarySurface.cpp
@@ -780,17 +780,20 @@ namespace DDraw
 		g_qpcPrevWaitEnd = qpcWaitEnd;
 		g_qpcDelayedFlipEnd = qpcWaitEnd;
 
-		Compat::ScopedThreadPriority prio(THREAD_PRIORITY_TIME_CRITICAL);
-		while (Time::qpcToMs(qpcWaitEnd - qpcNow) > 0)
 		{
-			Time::waitForNextTick();
-			flush();
-			qpcNow = Time::queryPerformanceCounter();
-		}
+			DDraw::ScopedThreadUnlock unlock;
+			Compat::ScopedThreadPriority prio(THREAD_PRIORITY_TIME_CRITICAL);
+			while (Time::qpcToMs(qpcWaitEnd - qpcNow) > 0)
+			{
+				Time::waitForNextTick();
+				flush();
+				qpcNow = Time::queryPerformanceCounter();
+			}
 
-		while (qpcWaitEnd - qpcNow > 0)
-		{
-			qpcNow = Time::queryPerformanceCounter();
+			while (qpcWaitEnd - qpcNow > 0)
+			{
+				qpcNow = Time::queryPerformanceCounter();
+			}
 		}
 		g_qpcDelayedFlipEnd = Time::queryPerformanceCounter();
 	}

--- a/DDrawCompat/DDraw/ScopedThreadLock.h
+++ b/DDrawCompat/DDraw/ScopedThreadLock.h
@@ -17,4 +17,18 @@ namespace DDraw
 			Dll::g_origProcs.ReleaseDDThreadLock();
 		}
 	};
+
+	class ScopedThreadUnlock
+	{
+	public:
+		ScopedThreadUnlock()
+		{
+			Dll::g_origProcs.ReleaseDDThreadLock();
+		}
+
+		~ScopedThreadUnlock()
+		{
+			Dll::g_origProcs.AcquireDDThreadLock();
+		}
+	};
 }


### PR DESCRIPTION
Hey! We're working on [Buccaneer](https://store.steampowered.com/app/2702120/Buccaneer/) that benefits greatly from DDrawCompat, and we use it to eliminate any compatibility issues the game had, and to limit the FPS via `FpsLimiter=flipend(30)`. With this setup, we've noticed that the loading times in the game are prohibitively long and random, sometimes taking up to several minutes.

I dug into the game code and found out something rather horrifying - during the loading sequences, the game performs DDraw calls from two threads:
* The main game thread creates surfaces and other resources.
* An auxillary thread spawned for the loading screens drives the loading screen and flips the primary buffer **in a busy loop**.

Now, Buccaneer is a horribly coded game, the worst one I have seen so far, but there is a way to improve this scenario - DDrawCompat takes a DDLock in every single wrapped call, effectively serializing use of DirectDraw. However, that lock is **not** relinquished during the busy loop in `RealPrimarySurface::waitForFlipFpsLimit`. In this PR, I introduced a scoped DDLock unlock to release the lock during this busy loop.

With this PR, loading times in Buccaneer are greatly improved, I can hardly spot the loading times at all. That said, I am not 100% sure if releasing the lock here is safe - perhaps the lock needs to be reinstated for the `RealPrimarySurface::flush` call inside both busy loops? The PR worked fine as-is for us in Buccaneer, but not every game may be this lucky.